### PR TITLE
chore: fetch token meta from chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ It will show tasks that you can run with Nx.
 
 - Gain familiarity interacting with EVM Smart Contract from a web app.
 
+### Technical highlights
+
+- Use Viem directly instead of Wagmi. Wagmi is a React Query wrapped of Viem to provide React Hooks for all of Viem's features. As a consequence, one ends up relying on `useEffect` to tell when something changed from Wagmi hooks. I decided to use Viem to one, keep it simple. And two, further understand Wagmi's decisions when wrapping Viem.
+- React Query. For the app's state management, async operations and HTTP/WS's cache. It's worth nothing that some data is preloaded, as for instance, the Token's name, and symbol, not to block the rendering with data that doesn't change often. Data is revalidated in the background after the first mount.
+
 ### TODO
 
 - [x] ops: deploy the app to the internet.
@@ -67,7 +72,7 @@ It will show tasks that you can run with Nx.
 - [ ] feat: maybe more wallets. use ConnectKit, Rainbow or similar
 - [ ] feat: Support ENS. Display ENS instead of address, if any.
 - [ ] feat: asynchronous transaction status. Allow users to close the app and come later to check the status of their last transaction(s).
-- [ ] tech-debt: remove token hardcoded decimals and token name. get its metadata from chain.
+- [x] tech-debt: remove token hardcoded decimals and token name. get its metadata from chain.
 
 ### Things I struggled the most with
 

--- a/apps/bank/src/app/page.tsx
+++ b/apps/bank/src/app/page.tsx
@@ -18,7 +18,9 @@ import {
 
 import { useWallet } from '../store/useWallet';
 import { useBankBalance } from '../store/useBankBalance';
+
 import { Deposit } from '../components/deposit/deposit';
+import { TokenSymbol } from '../components/token-symbol';
 
 export default function Index() {
   const { data: wallet } = useWallet();
@@ -34,7 +36,7 @@ export default function Index() {
             </Heading>
             <Heading as="div" size="lg">
               <span className="text-emerald-600">{balance.toString()}</span>{' '}
-              <span>TTK</span>
+              <TokenSymbol />
             </Heading>
           </HStack>
         </CardHeader>

--- a/apps/bank/src/components/deposit/deposit-form.tsx
+++ b/apps/bank/src/components/deposit/deposit-form.tsx
@@ -19,6 +19,7 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { ExternalLinkIcon } from '@chakra-ui/icons';
+import { TokenSymbol } from '../token-symbol';
 
 type Props = {
   onDeposit?: (amount: number) => Promise<void>;
@@ -96,7 +97,9 @@ export function DepositForm({
         </NumberInput>
       </FormControl>
       <HStack spacing={4} fontSize="sm">
-        <Text>Allowance: {allowance} TTK</Text>
+        <Text>
+          Allowance: {allowance} <TokenSymbol />
+        </Text>
         <Link
           href="https://sepolia.etherscan.io/address/0x9aF18838611950953823154a04a14d2A34eE615e#writeContract#F1"
           isExternal

--- a/apps/bank/src/components/deposit/deposit.tsx
+++ b/apps/bank/src/components/deposit/deposit.tsx
@@ -8,7 +8,7 @@ import { useWallet } from '../../store/useWallet';
 import { DepositForm as Form } from './deposit-form';
 import { TransactionReceipt } from 'viem';
 import { useBankBalance } from '../../store/useBankBalance';
-import { useTokenQuery } from '../../store/useToken';
+import { useTokenUserData } from '../../store/useToken';
 
 type TransactionStatus =
   | {
@@ -30,7 +30,7 @@ type TransactionStatus =
 export function Deposit() {
   const { data, status } = useWallet();
   const { refetch: refetchBankBalance } = useBankBalance();
-  const { data: tokenData, refetch: refetchTokenData } = useTokenQuery();
+  const { data: tokenData, refetch: refetchTokenData } = useTokenUserData();
 
   const [txStatus, setTxStatus] = useState<TransactionStatus>({
     status: 'pending',

--- a/apps/bank/src/components/token-symbol.tsx
+++ b/apps/bank/src/components/token-symbol.tsx
@@ -1,0 +1,13 @@
+import { Text, type As } from '@chakra-ui/react';
+
+import { useTokenMeta } from '../store/useToken';
+
+export function TokenSymbol({ as = 'span' }: { as?: As }) {
+  const { data: meta } = useTokenMeta();
+
+  return (
+    <Text as={as}>
+      <abbr title={meta.name}>{meta.symbol}</abbr>
+    </Text>
+  );
+}

--- a/apps/bank/src/store/useToken.ts
+++ b/apps/bank/src/store/useToken.ts
@@ -46,3 +46,60 @@ export function useTokenUserData() {
     enabled: status === 'success' && wallet != null,
   });
 }
+
+export function useTokenMeta() {
+  const { data: wallet, status } = useWallet();
+
+  return useQuery({
+    queryKey: ['token-metadata'],
+    queryFn: async () => {
+      // Enabled is false if the wallet is not connected
+      if (!wallet) {
+        throw new Error('Expected Wallet to be connected.');
+      }
+
+      const results = await wallet.publicClient.multicall({
+        contracts: [
+          {
+            ...token,
+            functionName: 'name',
+          },
+          {
+            ...token,
+            functionName: 'symbol',
+          },
+          {
+            ...token,
+            functionName: 'decimals',
+          },
+        ],
+      });
+
+      // @TODO: Handle better
+      if (results.some((r) => r.status === 'failure')) {
+        console.log('Failed to read token contract', results);
+        throw new Error('Failed to read token contract');
+      }
+
+      return {
+        name: results[0].result as string,
+        symbol: results[1].result as string,
+        decimals: results[2].result as number,
+      };
+    },
+    // This data is not expected to change frequently so we can cache it for a long time
+    // We use initialData to populate the cache and combine staleTime with initialDataUpdatedAt to
+    // refetch data after mounting, and then every 5 minutes
+    staleTime: 1000 * 60 * 5,
+    initialData: {
+      name: 'BankToken',
+      symbol: 'TTK',
+      decimals: 1200,
+    },
+    initialDataUpdatedAt: Date.now() - 1000 * 60 * 5,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    enabled: status === 'success' && wallet != null,
+  });
+}

--- a/apps/bank/src/store/useToken.ts
+++ b/apps/bank/src/store/useToken.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { token, bank } from '@app/contract';
 import { useWallet } from './useWallet';
 
-export function useTokenQuery() {
+export function useTokenUserData() {
   const { data: wallet, status } = useWallet();
 
   return useQuery({


### PR DESCRIPTION
Now the token's symbol, name and decimals are revalidated against the chain.

Use hardcoded data to populate the App's cache but revalidates the token metadata once mount.

Opportunistic refactor: rename `useTokenQuery` to `useTokenUserData`.